### PR TITLE
Added support for hybrid framework style base controllers

### DIFF
--- a/GDev.Umbraco.Testing/Controllers/BaseHybridController.cs
+++ b/GDev.Umbraco.Testing/Controllers/BaseHybridController.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Web.Mvc;
+using Umbraco.Core.Logging;
+using Umbraco.Web;
+using Umbraco.Web.Models;
+using Umbraco.Web.Mvc;
+
+namespace GDev.Umbraco.Testing.Controllers
+{
+    public abstract class BaseHybridController : SurfaceController, IRenderMvcController
+    {
+        protected UmbracoContext Context { get; private set; }
+
+        private readonly UmbracoHelper _umbraco;
+        public override UmbracoHelper Umbraco
+        {
+            get { return this._umbraco ?? base.Umbraco; }
+        }
+
+        protected BaseHybridController()
+        {
+            this.Context = UmbracoContext.Current;
+        }
+
+        protected BaseHybridController(UmbracoContext context) : base(context)
+        {
+            this.Context = context;
+        }
+
+        protected BaseHybridController(UmbracoContext context, UmbracoHelper helper) : base(context)
+        {
+            this.Context = context;
+            this._umbraco = helper;
+        }
+
+        public ActionResult Index(RenderModel model)
+        {
+            return CurrentTemplate(model);
+        }
+
+        protected ActionResult CurrentTemplate<T>(T model)
+        {
+            var template = ControllerContext.RouteData.Values["action"].ToString();
+            if (EnsurePhsyicalViewExists(template) == false)
+            {
+                throw new Exception("No physical template file was found for template " + template);
+            }
+
+            return View(template, model);
+        }
+
+        private bool EnsurePhsyicalViewExists(string template)
+        {
+            var result = ViewEngines.Engines.FindView(ControllerContext, template, null);
+            if (result.View == null)
+            {
+                LogHelper.Warn<RenderMvcController>("No physical template file was found for template " + template);
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/GDev.Umbraco.Testing/GDev.Umbraco.Testing.csproj
+++ b/GDev.Umbraco.Testing/GDev.Umbraco.Testing.csproj
@@ -278,6 +278,7 @@
   <ItemGroup>
     <Compile Include="ContextMocker.cs" />
     <Compile Include="Controllers\BaseRenderMvcController.cs" />
+    <Compile Include="Controllers\BaseHybridController.cs" />
     <Compile Include="Controllers\BaseSurfaceController.cs" />
     <Compile Include="Controllers\BaseUmbracoApiController.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/GDev.Umbraco.Tests/ControllerTests.cs
+++ b/GDev.Umbraco.Tests/ControllerTests.cs
@@ -28,6 +28,12 @@ namespace GDev.Umbraco.Tests
         }
 
         [Test]
+        public void CanInitializeHybridController()
+        {
+            Assert.DoesNotThrow(() => new MyHybridController(this._mocker.UmbracoContextMock));
+        }
+
+        [Test]
         public void CanInitializeUmbracoApiController()
         {
             Assert.DoesNotThrow(() => new MyUmbracoApiController(this._mocker.UmbracoContextMock));

--- a/GDev.Umbraco.Tests/Controllers/MyHybridController.cs
+++ b/GDev.Umbraco.Tests/Controllers/MyHybridController.cs
@@ -1,0 +1,11 @@
+﻿using GDev.Umbraco.Testing.Controllers;
+using Umbraco.Web;
+
+namespace GDev.Umbraco.Tests.Controllers
+{
+    public class MyHybridController : BaseHybridController
+    {
+        public MyHybridController(UmbracoContext context) : base(context) { }
+        public MyHybridController(UmbracoContext context, UmbracoHelper helper) : base(context, helper) { }
+    }
+}

--- a/GDev.Umbraco.Tests/GDev.Umbraco.Tests.csproj
+++ b/GDev.Umbraco.Tests/GDev.Umbraco.Tests.csproj
@@ -282,6 +282,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Controllers\MyRenderMvcController.cs" />
+    <Compile Include="Controllers\MyHybridController.cs" />
     <Compile Include="Controllers\MySurfaceController.cs" />
     <Compile Include="Controllers\MyUmbracoApiController.cs" />
     <Compile Include="ControllerTests.cs" />
@@ -339,7 +340,9 @@
     <Content Include="default.aspx" />
     <Content Include="Global.asax" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GDev.Umbraco.Testing\GDev.Umbraco.Testing.csproj">
       <Project>{1793b4e7-3468-45a2-8b7b-735c58837e72}</Project>


### PR DESCRIPTION
Firstly thanks for releasing this - will be very useful.

This PR is for a small addition to support "Hybrid Framework" style base controllers.  I call it that as the first time I saw the technique was [here](https://github.com/jbreuer/Hybrid-Framework-Best-Practices/blob/master/development/Umbraco.Extensions/Controllers/Base/BaseSurfaceController.cs).  The method is to have a base controller that inherits SurfaceController and implements IRenderMvcController (which isn't much code).  That way you can have one base controller for both types within your Umbraco application.
